### PR TITLE
Add point inc/decrement

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,36 @@
         "command": "incrementor.decByTen",
         "title": "Decrement by 10",
         "category": "Incrementor"
+      },
+      {
+        "command": "incrementor.incByOneX",
+        "title": "Increment by 1 the X part of a point",
+        "category": "Incrementor"
+      },
+      {
+        "command": "incrementor.decByOneX",
+        "title": "Decrement by 1 the X part of a point",
+        "category": "Incrementor"
+      },
+      {
+        "command": "incrementor.incByTenthX",
+        "title": "Increment by 0.1 the X part of a point",
+        "category": "Incrementor"
+      },
+      {
+        "command": "incrementor.decByTenthX",
+        "title": "Decrement by 0.1 the X part of a point",
+        "category": "Incrementor"
+      },
+      {
+        "command": "incrementor.incByTenX",
+        "title": "Increment by 10 the X part of a point",
+        "category": "Incrementor"
+      },
+      {
+        "command": "incrementor.decByTenX",
+        "title": "Decrement by 10 the X part of a point",
+        "category": "Incrementor"
       }
     ],
     "keybindings": [
@@ -189,6 +219,30 @@
       {
         "command": "incrementor.decByTen",
         "key": "ctrl+alt+cmd+down"
+      },
+      {
+        "command": "incrementor.incByOneX",
+        "key": "ctrl+right"
+      },
+      {
+        "command": "incrementor.decByOneX",
+        "key": "ctrl+left"
+      },
+      {
+        "command": "incrementor.incByTenthX",
+        "key": "ctrl+alt+right"
+      },
+      {
+        "command": "incrementor.decByTenthX",
+        "key": "ctrl+alt+left"
+      },
+      {
+        "command": "incrementor.incByTenX",
+        "key": "ctrl+alt+cmd+right"
+      },
+      {
+        "command": "incrementor.decByTenX",
+        "key": "ctrl+alt+cmd+left"
       }
     ]
   },

--- a/test/env/test-env.ts
+++ b/test/env/test-env.ts
@@ -18,3 +18,39 @@ const incByTen = '1px';
 
 // decByTen
 const decByTen = '1px';
+
+// incByOne a point
+const pointIncByOne = '10,100';
+
+// decByOne a point
+const pointDecByOne = '10,100';
+
+// incByTenth a point
+const pointIncByTenth = '10,100';
+
+// decByTenth a point
+const pointDecByTenth = '10,100';
+
+// incByTen a point
+const pointIncByTen = '10,100';
+
+// decByTen a point
+const pointDecByTen = '10,100';
+
+// incByOne a point
+const pointIncByOneX = '10,100';
+
+// decByOne a point
+const pointDecByOneX = '10,100';
+
+// incByTenth a point
+const pointIncByTenthX = '10,100';
+
+// decByTenth a point
+const pointDecByTenthX = '10,100';
+
+// incByTen a point
+const pointIncByTenX = '10,100';
+
+// decByTen a point
+const pointDecByTenX = '10,100';

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -86,13 +86,13 @@ describe('Numbers', function() {
                 sel = new vscode.Selection(4, 18, 4, 21);
                 vEditor.selection = sel;
                 text = vDoc.getText(vEditor.selection);
-                
-                try {  
+
+                try {
                     text.should.equal('1px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
 
@@ -101,12 +101,12 @@ describe('Numbers', function() {
             _.delay((done) => {
                 text = vDoc.getText(vEditor.selection);
 
-                try {  
+                try {
                     text.should.equal('2px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
     });
@@ -117,13 +117,13 @@ describe('Numbers', function() {
                 sel = new vscode.Selection(7, 18, 7, 21);
                 vEditor.selection = sel;
                 text = vDoc.getText(vEditor.selection);
-                
-                try {  
+
+                try {
                     text.should.equal('1px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
 
@@ -132,12 +132,12 @@ describe('Numbers', function() {
             _.delay((done) => {
                 text = vDoc.getText(vEditor.selection);
 
-                try {  
+                try {
                     text.should.equal('0px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
     });
@@ -148,13 +148,13 @@ describe('Numbers', function() {
                 sel = new vscode.Selection(10, 20, 10, 23);
                 vEditor.selection = sel;
                 text = vDoc.getText(vEditor.selection);
-                
-                try {  
+
+                try {
                     text.should.equal('1px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
 
@@ -163,12 +163,12 @@ describe('Numbers', function() {
             _.delay((done) => {
                 text = vDoc.getText(vEditor.selection);
 
-                try {  
+                try {
                     text.should.equal('1.1px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
     });
@@ -179,13 +179,13 @@ describe('Numbers', function() {
                 sel = new vscode.Selection(13, 20, 13, 23);
                 vEditor.selection = sel;
                 text = vDoc.getText(vEditor.selection);
-                
-                try {  
+
+                try {
                     text.should.equal('1px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
 
@@ -194,12 +194,12 @@ describe('Numbers', function() {
             _.delay((done) => {
                 text = vDoc.getText(vEditor.selection);
 
-                try {  
+                try {
                     text.should.equal('0.9px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
     });
@@ -210,13 +210,13 @@ describe('Numbers', function() {
                 sel = new vscode.Selection(16, 18, 16, 21);
                 vEditor.selection = sel;
                 text = vDoc.getText(vEditor.selection);
-                
-                try {  
+
+                try {
                     text.should.equal('1px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
 
@@ -225,12 +225,12 @@ describe('Numbers', function() {
             _.delay((done) => {
                 text = vDoc.getText(vEditor.selection);
 
-                try {  
+                try {
                     text.should.equal('11px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
     });
@@ -241,13 +241,13 @@ describe('Numbers', function() {
                 sel = new vscode.Selection(19, 18, 19, 21);
                 vEditor.selection = sel;
                 text = vDoc.getText(vEditor.selection);
-                
-                try {  
+
+                try {
                     text.should.equal('1px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
             }, 100, done);
         });
 
@@ -256,12 +256,395 @@ describe('Numbers', function() {
             _.delay((done) => {
                 text = vDoc.getText(vEditor.selection);
 
-                try {  
+                try {
                     text.should.equal('-9px');
                     done();
                 } catch (error) {
                     done(error);
-                } 
+                }
+            }, 100, done);
+        });
+    });
+});
+
+describe('Points', function() {
+    this.slow(110);
+    this.timeout(300);
+
+    beforeEach(function() {
+        vEditor = vscode.window.activeTextEditor;
+        vDoc = vEditor.document;
+        vSel = vEditor.selections;
+    });
+
+    describe('#incByOne()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(22, 23, 22, 29);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 10,101', function(done) {
+            vscode.commands.executeCommand('incrementor.incByOne');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,101');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#decByOne()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(25, 23, 25, 29);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 10,99', function(done) {
+            vscode.commands.executeCommand('incrementor.decByOne');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,99');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#incByTenth()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(28, 25, 28, 31);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 10,100.1', function(done) {
+            vscode.commands.executeCommand('incrementor.incByTenth');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100.1');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#decByTenth()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(31, 25, 31, 31);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 10,99.9', function(done) {
+            vscode.commands.executeCommand('incrementor.decByTenth');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,99.9');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#incByTen()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(34, 23, 34, 29);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 10,110', function(done) {
+            vscode.commands.executeCommand('incrementor.incByTen');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,110');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#decByTen()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(37, 23, 37, 29);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 10,90', function(done) {
+            vscode.commands.executeCommand('incrementor.decByTen');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,90');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#incByOneX()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(40, 24, 40, 30);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 11,100', function(done) {
+            vscode.commands.executeCommand('incrementor.incByOneX');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('11,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#decByOneX()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(43, 24, 43, 30);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 9,100', function(done) {
+            vscode.commands.executeCommand('incrementor.decByOneX');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('9,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#incByTenthX()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(46, 26, 46, 32);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 10.1,100', function(done) {
+            vscode.commands.executeCommand('incrementor.incByTenthX');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10.1,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#decByTenthX()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(49, 26, 49, 32);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 9.9,100', function(done) {
+            vscode.commands.executeCommand('incrementor.decByTenthX');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('9.9,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#incByTenX()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(52, 24, 52, 30);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 20,100', function(done) {
+            vscode.commands.executeCommand('incrementor.incByTenX');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('20,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+    });
+
+    describe('#decByTenX()', function() {
+        it('should have 10,100 as selected text', function(done) {
+            _.delay(done => {
+                sel = new vscode.Selection(55, 24, 55, 30);
+                vEditor.selection = sel;
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('10,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
+            }, 100, done);
+        });
+
+        it('should increment 10,100 to 0,100', function(done) {
+            vscode.commands.executeCommand('incrementor.decByTenX');
+            _.delay(done => {
+                text = vDoc.getText(vEditor.selection);
+
+                try {
+                    text.should.equal('0,100');
+                    done();
+                } catch (error) {
+                    done(error);
+                }
             }, 100, done);
         });
     });


### PR DESCRIPTION
Add the ability to inc or dec a 2D point.

A point is compose by 2 coordinates `X,Y` where X and Y are numbers.

The goal of this feature is to be able to increment or decrement X or Y when the point is selected.

Practical use case:
This is usefull, for example, when you edit an svg file, with a live preview, and you want to move a point quickly with precision. No need to select X coordinate and inc/dec it, and then select Y coordinate and inc/dec it.
Here you can just select your point `X,Y` and inc/dec it both by just press up/down or left/right arrow key with your shortcut.

Enjoy !