### PR TITLE
Add change case operation and keep enum case

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,6 +130,16 @@
           "type": "boolean",
           "default": true,
           "description": "After reaching the end of an Enum set, start back at the beginning."
+        },
+        "incrementor.keepEnumCase": {
+          "type": "boolean",
+          "default": true,
+          "description": "Attempt to keep word casing of the next entry of an Enum set. Enums must be defined in lowercase for it to work."
+        },
+        "incrementor.changeCase": {
+          "type": "boolean",
+          "default": true,
+          "description": "If a selected word is not a Number or an Enum, change its form to lowercase, Capitalized, or UPPERCASE."
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -251,24 +251,27 @@ export class Incrementor {
 
             let wordChanged = tempString;
             let found = false;
-            for (const enums of this.settings['enums']) {
-                if (_.includes(enums, tempString)) {
-                    found = true;
-                    break;
-                }
-            }
-
             let keepCase = (word: string): string => word;
-            if (found === false) {
-                if (/^[A-Z1-9_]+$/.test(tempString)) {
-                    keepCase = (word) => word.toUpperCase();
-                } else if (/^[A-Z][a-z1-9_]+$/.test(tempString)) {
-                    keepCase = (word) => word.charAt(0).toUpperCase() + word.slice(1);
-                } else {
-                    keepCase = (word) => word.toLowerCase();
+
+            if (this.settings['keepEnumCase']) {
+                for (const enums of this.settings['enums']) {
+                    if (_.includes(enums, tempString)) {
+                        found = true;
+                        break;
+                    }
                 }
 
-                tempString = tempString.toLowerCase();
+                if (found === false) {
+                    if (/^[A-Z1-9_]+$/.test(tempString)) {
+                        keepCase = (word) => word.toUpperCase();
+                    } else if (/^[A-Z][a-z1-9_]+$/.test(tempString)) {
+                        keepCase = (word) => word.charAt(0).toUpperCase() + word.slice(1);
+                    } else {
+                        keepCase = (word) => word.toLowerCase();
+                    }
+
+                    tempString = tempString.toLowerCase();
+                }
             }
 
             for (const enums of this.settings['enums']) {
@@ -314,33 +317,35 @@ export class Incrementor {
         const word = this.wordString;
         let wordChanged = word;
 
-        switch (this.delta) {
-            case this.action.incByOne:
-                if (word.charAt(0).toLowerCase() === word.charAt(0)) {
-                    wordChanged = word.charAt(0).toUpperCase() + word.slice(1);
-                } else {
+        if (this.settings['changeCase']) {
+            switch (this.delta) {
+                case this.action.incByOne:
+                    if (word.charAt(0).toLowerCase() === word.charAt(0)) {
+                        wordChanged = word.charAt(0).toUpperCase() + word.slice(1);
+                    } else {
+                        wordChanged = word.toUpperCase();
+                    }
+                    break;
+
+                case this.action.decByOne:
+                    if (word.toUpperCase() === word) {
+                        wordChanged = word.charAt(0) + word.slice(1).toLowerCase();
+                    } else {
+                        wordChanged = word.toLowerCase();
+                    }
+                    break;
+
+                case this.action.incByTen:
                     wordChanged = word.toUpperCase();
-                }
-                break;
+                    break;
 
-            case this.action.decByOne:
-                if (word.toUpperCase() === word) {
-                    wordChanged = word.charAt(0) + word.slice(1).toLowerCase();
-                } else {
+                case this.action.decByTen:
                     wordChanged = word.toLowerCase();
-                }
-                break;
+                    break;
 
-            case this.action.incByTen:
-                wordChanged = word.toUpperCase();
-                break;
-
-            case this.action.decByTen:
-                wordChanged = word.toLowerCase();
-                break;
-
-            default:
-                return false;
+                default:
+                    return false;
+            }
         }
 
         if (wordChanged !== word) {


### PR DESCRIPTION
Hi,

Thanks for this plugin, I was looking for a replacement for [Inc-Dec-Value](https://github.com/rmaksim/Sublime-Text-2-Inc-Dec-Value) for Sublime Text in VS Code.

To be completely happy I missed a feature that when I try "incrementing" a word it would change its casing like so: lowercase → Capitalized → UPPERCASE. This PR adds that.

The case change will be applied unless the number or enum operation was applied first. This also introduced a "problem" if a word is technically an enum but doesn't match case exactly, like `True` → `TRUE` rather than `True` → `False`, so I also included this feature, which resolves #3.

Both features can be switched off to restore old behaviour using `keepEnumCase` and `changeCase` options.